### PR TITLE
Connect busy-signal

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,6 @@ class ScalaLanguageClient extends AutoLanguageClient {
     const serverProcess = this.spawnChildNode([serverPath], {
       cwd: projectPath
     });
-    this.captureServerErrors(serverProcess);
     return serverProcess;
   }
 
@@ -57,10 +56,6 @@ class ScalaLanguageClient extends AutoLanguageClient {
     });
   }
 
-  consumeBusySignal(busySignal) {
-    this.busySignal = busySignal;
-  }
-
   busyMessageFormat(text) {
     return `${this.getServerName()}: ${text}`;
   }
@@ -77,7 +72,7 @@ class ScalaLanguageClient extends AutoLanguageClient {
         );
       }
     } else if (init) {
-      this.busyMessage = this.busySignal.reportBusy(
+      this.busyMessage = this.busySignalService.reportBusy(
         this.busyMessageFormat(text),
         { revealTooltip: reveal }
       );

--- a/lib/main.js
+++ b/lib/main.js
@@ -47,6 +47,44 @@ class ScalaLanguageClient extends AutoLanguageClient {
   // Currently we just turn off these notifications, because sbt doesn't
   // recognize them anyway
   filterChangeWatchedFiles(filePath) { return false; }
+
+  preInitialization(connection) {
+    connection.onLogMessage(params => {
+      if (params.type === 4 && params.message === 'Done') {
+        this.updateBusyMessage();
+      } else {
+        const init = (params.type === 4 && params.message === 'Processing');
+        this.updateBusyMessage(params.message, init);
+      }
+    });
+  }
+
+  consumeBusySignal(busySignal) {
+    this.busySignal = busySignal;
+  }
+
+  busyMessageFormat(text) {
+    return `${this.getServerName()}: ${text}`;
+  }
+
+  updateBusyMessage(text = '', init = false, reveal = false) {
+    if (this.busyMessage != null) {
+      if (text === '') {
+        this.busyMessage.dispose();
+        this.busyMessage = null;
+      } else {
+        this.busyMessage.setTitle(
+          this.busyMessageFormat(text),
+          { revealTooltip: reveal }
+        );
+      }
+    } else if (init) {
+      this.busyMessage = this.busySignal.reportBusy(
+        this.busyMessageFormat(text),
+        { revealTooltip: reveal }
+      );
+    }
+  }
 }
 
 module.exports = new ScalaLanguageClient()

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
       "versions": {
         "2.0.0": "consumeLinterV2"
       }
+    },
+    "atom-ide-busy-signal": {
+      "versions": {
+        "0.1.0": "consumeBusySignal"
+      }
     }
   }
 }


### PR DESCRIPTION
Start spinning on `didSave`, stop on `publishDiagnostics`, show messages from `window/logMessage` notifications.

https://github.com/facebook-atom/atom-ide-ui/blob/master/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/types.js